### PR TITLE
Fixes 5: Cannot dismiss mobile navbar when clicking away from menu with mouse

### DIFF
--- a/lib/js/mobile_navbar.js
+++ b/lib/js/mobile_navbar.js
@@ -1,1 +1,14 @@
-$(document).ready(function(){$(document).on("touchstart",function(){tapDetected=!0}),$(document).on("touchmove",function(){tapDetected=!1});var t=["navbar-toggle","dropdown-toggle","nav-link"];$(document).on("click touchend",function(e){if("touchend"===e.type&&tapDetected){var n=$(e.target),o=$(".navbar-collapse").is(":visible");o&&n.hasClass(t[0])===!1&&n.hasClass(t[1])===!1&&n.hasClass(t[2])===!1&&$("button.navbar-toggle").click()}})});
+const EVENT = Object.freeze({
+  touchStart: 'touchStart',
+  touchEnd: 'touchend',
+  click: 'click'
+});
+
+$(document).ready(function() {
+  var t = ["navbar-toggle", "dropdown-toggle", "nav-link"];
+  $(document).on("click touchend", function(e) {
+          var n = $(e.target),
+              o = $(".navbar-collapse").is(":visible");
+          o && n.hasClass(t[0]) === !1 && n.hasClass(t[1]) === !1 && n.hasClass(t[2]) === !1 && $("button.navbar-toggle").click();
+  })
+});


### PR DESCRIPTION
# Purpose of PR
As a user I should be able to dismiss the responsive menu when I click outside of the menu area

# Change log
* Refactored code
* Fixed issue where clicking mouse outside of menubar will result menubar to remain open