### PR TITLE
Fixes #17: Horizontal scrollbar appears when user clicks on page outside of navbar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,9 +32,11 @@
         {% else %}
           {% include footer.html %}
         {% endif %}
-    </div>
   </main>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script
+    src="https://code.jquery.com/jquery-3.3.1.min.js"
+    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+    crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     <script src="{{ "lib/js/mobile_navbar.js" | relative_url }}"></script>
     <script src="{{ "lib/js/ie10-viewport-bug-workaround.js" | relative_url }}"></script>

--- a/lib/js/mobile_navbar.js
+++ b/lib/js/mobile_navbar.js
@@ -1,1 +1,28 @@
-var EVENTS=Object.freeze({clickTouchEnd:"click touchend",touchEnd:"touchend",touchStart:"touchstart",touchMove:"touchmove",click:"click"}),tapDetected=!1;$(document).ready(function(){$(document).on(EVENTS.touchStart,function(){tapDetected=!0}),$(document).on(EVENTS.touchMove,function(){tapDetected=!1});var t=["navbar-toggle","dropdown-toggle","nav-link"];$(document).on(EVENTS.clickTouchEnd,function(c){var e=$(c.target),o=$(".navbar-collapse").is(":visible");return c.type===EVENTS.touchEnd&&tapDetected||c.type===EVENTS.click?void(o&&e.hasClass(t[0])===!1&&e.hasClass(t[1])===!1&&e.hasClass(t[2])===!1&&$("button.navbar-toggle").click()):void 0})});
+var EVENTS = Object.freeze({
+  clickTouchEnd: "click touchend",
+  touchEnd: "touchend",
+  touchStart: "touchstart",
+  touchMove: "touchmove",
+  click: "click"
+})
+var tapDetected = !1;
+$(document).ready(function() {
+$(document).on(EVENTS.touchStart, function() {
+  tapDetected = !0
+}), $(document).on(EVENTS.touchMove, function() {
+  tapDetected = !1
+});
+var t = ["navbar-toggle", "dropdown-toggle", "nav-link"];
+$("main").on(EVENTS.clickTouchEnd, function(c) {
+  if ($(window).width() <= 768) {
+    var o = $(".navbar-collapse").is(":visible");
+    var e = $(c.target);
+    if (c.type === EVENTS.touchEnd && tapDetected || c.type === EVENTS.click){
+      if(o && e.hasClass(t[0]) === !1 && e.hasClass(t[1]) === !1 && e.hasClass(t[2]) === !1) {
+          $("button.navbar-toggle").click();
+          c.stopPropagation();
+      }
+    }
+  }
+})
+});


### PR DESCRIPTION
Fixes #17

# Purpose of update
Fixes issue where when user clicks on the page outside of navbar with window width > 768px, the horizontal scroll bar appears by the navbar and floats upwards.

# Change log
* Remove extraneous </div> tag causing jQuery to fail when processing mouse clicks and taps for mobile_navbar.js

* Updated mobile_navbar logic to only apply if user has a screen size 768px or less to
prevent horizontal scroll bar from appearing when user clicks on screen

The logic should only activate in responsive mode

* Upgraded jQuery to v3.3.1

# Test Plan
1. go to alexwang.ca
2. Click anywhere on the page except the navbar

Expected result: User should not see any changes on the page.

