### PR TITLE
Merge github menu item from navbar into contacts drop down menu

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -24,13 +24,19 @@
                     <li><a href="#experience">experience</a></li>
                     <li><a href="#events">events</a></li> 
                 {% endif %}
-                <li><a href="https://github.com/alexwang-16">github</a></li>
                 <li><a href="https://alexopensource.wordpress.com/">blog</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">contact <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                        <li><a class="nav-link" href="mailto:alex.lik.wang@outlook.com?subject=Greetings&nbsp;from&nbsp;alexwang.ca">email</a></li>
-                        <li><a class="nav-link" href="https://www.linkedin.com/in/alex-lh-wang">linkedin</a></li>
+                        <li>
+                            <a class="nav-link" href="https://github.com/alexwang-16">github</a>
+                        </li>
+                        <li>
+                            <a class="nav-link" href="https://www.linkedin.com/in/alex-lh-wang">linkedin</a>
+                        </li>
+                        <li>
+                            <a class="nav-link" href="mailto:alex.lik.wang@outlook.com?subject=Greetings&nbsp;from&nbsp;alexwang.ca">email</a>
+                        </li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
Fixes #22 
# Purpose of update
Merge github menu item from navbar into contacts drop down menu

# Change log
* Merge github menu item in navbar into contact dropdown menu

* reorganized contact drop down menu based on most accessed to least
accessed contact method: github > linkedin > email

# Test Plan
1. Navigate to alexwang.ca
2. Click on contacts drop down menu from navbar
3. User should see Github, Linkedin, Email

Repeat the same steps, but on mobile browser on iPhone 

Expected result:
User should see Github menu under contacts drop down menu only